### PR TITLE
Fix #66: oEmbedのボタンが押せない問題を修正

### DIFF
--- a/hooks/oembed.php
+++ b/hooks/oembed.php
@@ -42,3 +42,21 @@ add_action( 'embed_head', function () {
 	$style = str_replace( 'sourceMappingURL=', 'sourceMappingURL=' . get_template_directory_uri() . '/assets/css/', $style ); // Remove source map.
 	printf( "<style>\n%s\n</style>", $style );
 } );
+
+/**
+ * Allow top navigation for own site's oEmbed iframe.
+ *
+ * This enables target="_top" links in embed-content.php to work properly.
+ *
+ * @see https://github.com/fumikito/kyom/issues/66
+ */
+add_filter( 'embed_oembed_html', function ( $html, $url ) {
+	if ( false !== strpos( $url, home_url() ) ) {
+		$html = str_replace(
+			'sandbox="',
+			'sandbox="allow-top-navigation-by-user-activation ',
+			$html
+		);
+	}
+	return $html;
+}, 10, 2 );


### PR DESCRIPTION
## Summary
- 自サイトのoEmbed iframe に `allow-top-navigation-by-user-activation` を追加
- これにより `target="_top"` のリンクがユーザークリック時に同じタブで遷移可能に

## 原因
WordPressのoEmbed iframeは `sandbox` 属性付きで埋め込まれるが、デフォルトでは `allow-top-navigation` が含まれていないため、`target="_top"` でのナビゲーションがブロックされていた。

## 修正内容
`embed_oembed_html` フィルターで自サイトURLの場合のみ sandbox 属性に `allow-top-navigation-by-user-activation` を追加。

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)