### PR TITLE
Fix PHP 8.1 deprecation in WordPressOrg::get_profile

### DIFF
--- a/app/Fumikito/Kyom/Service/WordPressOrg.php
+++ b/app/Fumikito/Kyom/Service/WordPressOrg.php
@@ -41,6 +41,7 @@ class WordPressOrg {
 			if ( is_wp_error( $response ) ) {
 				return [];
 			}
+			$data              = [];
 			$data['url']       = $url;
 			$data['downloads'] = 0;
 			$html5             = new HTML5();

--- a/app/Fumikito/Kyom/Service/WordPressOrg.php
+++ b/app/Fumikito/Kyom/Service/WordPressOrg.php
@@ -48,22 +48,28 @@ class WordPressOrg {
 			$document          = $html5->loadHTML( $response['body'] );
 			// Get since.
 			$member_since = '';
-			foreach ( $document->getElementById( 'user-member-since' )->getElementsByTagName( 'strong' ) as $strong ) {
-				/** @var \DOMElement $strong */
-				$member_since .= $strong->nodeValue;
+			$since_el     = $document->getElementById( 'user-member-since' );
+			if ( $since_el ) {
+				foreach ( $since_el->getElementsByTagName( 'strong' ) as $strong ) {
+					/** @var \DOMElement $strong */
+					$member_since .= $strong->nodeValue;
+				}
 			}
 			if ( $member_since ) {
 				$data['member_since'] = strtotime( $member_since );
 			}
 			// Get badges.
-			$badges = [];
-			foreach ( $document->getElementById( 'user-badges' )->getElementsByTagName( 'li' ) as $li ) {
-				$badge = [];
-				foreach ( $li->getElementsByTagName( 'div' ) as $div ) {
-					$badge['label'] = trim( $div->nextSibling->nodeValue );
-					$badge['class'] = explode( ' ', $div->getAttribute( 'class' ) );
-					if ( $badge['label'] && $badge['class'] ) {
-						$badges[] = $badge;
+			$badges    = [];
+			$badges_el = $document->getElementById( 'user-badges' );
+			if ( $badges_el ) {
+				foreach ( $badges_el->getElementsByTagName( 'li' ) as $li ) {
+					$badge = [];
+					foreach ( $li->getElementsByTagName( 'div' ) as $div ) {
+						$badge['label'] = trim( $div->nextSibling->nodeValue );
+						$badge['class'] = explode( ' ', $div->getAttribute( 'class' ) );
+						if ( $badge['label'] && $badge['class'] ) {
+							$badges[] = $badge;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

`WordPressOrg::get_profile()` assigned keys to `$data` while it was still `false` (the cache-miss return value from `get_transient()`). PHP 8.1 emits a deprecation warning for this implicit `false → []` conversion. With `WP_DEBUG_DISPLAY = true` on production, the warning bled into HTML output and broke the homepage layout (the `wordpress-activities` block uses this method).

## Change

Initialize `$data = []` explicitly after the successful `wp_remote_get` branch.

## Test plan

- [ ] Deploy theme, confirm homepage renders without the deprecation banner at the top
- [ ] Confirm the wordpress-activities block still shows profile data (member since, badges, downloads)