### PR TITLE
register_sidebarをwidgets_initフックに移動（WP 6.7 textdomain JIT Notice解消）

### DIFF
--- a/hooks/menu-and-widgets.php
+++ b/hooks/menu-and-widgets.php
@@ -7,25 +7,29 @@
 
 Kunoichi\SetMenu::enable();
 
-// Register sidebar
-register_sidebar( [
-	'name'          => __( 'After Article', 'kyom' ),
-	'id'            => 'normal-sidebar',
-	'description'   => __( 'Displayed just after main content. 4 widgets are the best looking.', 'kyom' ),
-	'before_widget' => '<div id="%1$s" class="widget normal-widget"><div class="normal-widget-inner %2$s">',
-	'after_widget'  => '</div></div>',
-	'before_title'  => '<h2  class="uk-heading-line uk-text-center normal-widget-title"><span>',
-	'after_title'   => '</span></h2>',
-] );
-register_sidebar( [
-	'name'          => __( 'Footer Sidebar', 'kyom' ),
-	'id'            => 'footer-sidebar',
-	'description'   => __( 'Displayed in footer. Settling 4 widgets is recommended.', 'kyom' ),
-	'before_widget' => '<div id="%1$s" class="widget site-footer-widget %2$s">',
-	'after_widget'  => '</div>',
-	'before_title'  => '<h2 class="site-footer-widget-title">',
-	'after_title'   => '</h2>',
-] );
+// Register sidebars.
+// NOTE: Must be inside `widgets_init` because translation functions
+// called earlier than `init` trigger _load_textdomain_just_in_time notice since WP 6.7.
+add_action( 'widgets_init', function () {
+	register_sidebar( [
+		'name'          => __( 'After Article', 'kyom' ),
+		'id'            => 'normal-sidebar',
+		'description'   => __( 'Displayed just after main content. 4 widgets are the best looking.', 'kyom' ),
+		'before_widget' => '<div id="%1$s" class="widget normal-widget"><div class="normal-widget-inner %2$s">',
+		'after_widget'  => '</div></div>',
+		'before_title'  => '<h2  class="uk-heading-line uk-text-center normal-widget-title"><span>',
+		'after_title'   => '</span></h2>',
+	] );
+	register_sidebar( [
+		'name'          => __( 'Footer Sidebar', 'kyom' ),
+		'id'            => 'footer-sidebar',
+		'description'   => __( 'Displayed in footer. Settling 4 widgets is recommended.', 'kyom' ),
+		'before_widget' => '<div id="%1$s" class="widget site-footer-widget %2$s">',
+		'after_widget'  => '</div>',
+		'before_title'  => '<h2 class="site-footer-widget-title">',
+		'after_title'   => '</h2>',
+	] );
+} );
 
 /**
  * Register menus.


### PR DESCRIPTION
## 概要

WP 6.7以降、本番・ローカルの両方で以下のNoticeが出ていた。

> Notice: 関数 _load_textdomain_just_in_time が誤って呼び出されました。kyom ドメインの翻訳の読み込みが早すぎました。

## 原因

`hooks/menu-and-widgets.php` で `register_sidebar()` がファイル直下（`functions.php` 読み込み中＝`init` より前）に実行されており、引数内の `__()` が翻訳の遅延ロードを `init` 前に発動させていた。

## 修正

2つの `register_sidebar()` 呼び出しを `widgets_init` フック内に移動（こちらが本来の作法）。

## 検証

- `wp --require=<doing_it_wrong_runフックでバックトレース出力>` で原因箇所を特定
- 修正後、WP-CLI実行時のNoticeが消えることを確認
- `wp eval` でサイドバー2つ（normal-sidebar / footer-sidebar）の登録維持を確認
- ローカルフロントページでウィジェットの描画を確認
- phpcs パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)