### PR TITLE
GitHub Actionsの非推奨警告を解消

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       name: production
       url: https://takahashifumiki.com
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v6
 
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install NPM
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -33,16 +33,13 @@ jobs:
         run: bash bin/build.sh refs/tags/${{ github.sha }}
 
       - name: Deploy to Server
-        id: deploymaster
-        uses: Pendect/action-rsyncer@v1.1.0
         env:
-          DEPLOY_KEY: ${{secrets.ID_RSA_FUMIKI_VPS_SAKURA}}
-        with:
-          flags: '-rptv --checksum --delete'
-          options: ''
-          ssh_options: ''
-          src: './'
-          dest: 'fumiki@fumiki.sakura.ne.jp:/home/fumiki/www/main/wp-content/themes/kyom/'
-
-      - name: Display Deploy Status
-        run: echo "${{ steps.deploymaster.outputs.status }}"
+          DEPLOY_KEY: ${{ secrets.ID_RSA_FUMIKI_VPS_SAKURA }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H fumiki.sakura.ne.jp >> ~/.ssh/known_hosts
+          rsync -rptv --checksum --delete \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            ./ fumiki@fumiki.sakura.ne.jp:/home/fumiki/www/main/wp-content/themes/kyom/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       name: release
       url: https://github.com/fumikito/kyom/releases
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
 
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install NPM
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -20,7 +20,7 @@ jobs:
     name: PHP Syntax Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v6
 
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
@@ -40,10 +40,10 @@ jobs:
     name: Test Assets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v6
 
       - name: Install NPM
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 


### PR DESCRIPTION
## 概要

PR #89 のデプロイ実行時に出ていた2件の非推奨警告を解消する。

1. **Node.js 20 actions deprecated** — 2026/6/16からNode 24強制、9/16にランナーから削除予定
2. **`set-output` deprecated** — `Pendect/action-rsyncer@v1.1.0`（2020年製・メンテ停止）が内部で使用

## 変更内容

### 全ワークフロー共通
- `actions/setup-node@v4` → `@v6`（Node 24ランタイム対応。インストールするNode自体は20のまま変更なし）
- `actions/checkout@main` / `@master` → `@v6` にピン留め（浮動参照は将来の破壊的変更を勝手に拾うため）

### deploy.yml
- `Pendect/action-rsyncer@v1.1.0` を素のrsyncステップに置換
  - フラグ（`-rptv --checksum --delete`）・src・destは**完全に同一**。デプロイ結果は変わらない
  - サードパーティ依存が消え、set-output警告も解消
  - SSH失敗時は何も転送されずジョブが落ちるだけ（安全側に倒れる）
- 旧アクションのoutputに依存していた「Display Deploy Status」ステップを削除（rsync -v の出力で代替）

## 検証

- `actionlint` パス
- 本PRのCIで wordpress.yml の変更（checkout/setup-node更新）が実際に動作することを確認
- deploy.yml はマージ時のデプロイ実行が実地検証となる（失敗時は本番に影響なし）

## 残課題（別PR推奨）

`release.yml` の `actions/create-release@v1` / `actions/upload-release-asset@v1.0.1` はアーカイブ済みの非推奨アクション。`gh release create` への置換を推奨するが、タグ発行でしか検証できないため本PRには含めない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)