### PR TITLE
release-drafter導入とリリースワークフローの現代化

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: 'Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: 'Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: Kyom Theme Workflow
 
+# Release Drafterのドラフトを公開するとタグが作成され、このワークフローが起動する。
+# ビルド済みテーマのZIPを公開済みリリースに添付する。
 on:
-  push:
-    tags:
-      - '*.*.*'
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
 
 jobs:
   tags-check:
@@ -39,29 +44,10 @@ jobs:
       - name: Build package.
         run: bash bin/build.sh ${{ github.ref }}
 
-      - name: Deploy Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
       - name: Create Zip
         run: zip -r ${{ github.event.repository.name }}.zip ./
 
       - name: Upload Release Zip
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.1
+        run: gh release upload ${{ github.event.release.tag_name }} ${{ github.event.repository.name }}.zip --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./${{ github.event.repository.name }}.zip
-          asset_name: ${{ github.event.repository.name }}.zip
-          asset_content_type: application/zip


### PR DESCRIPTION
## 概要

PR #90 の残課題。アーカイブ済みの非推奨アクション（`actions/create-release@v1` / `actions/upload-release-asset@v1.0.1`）を除去し、他リポジトリ（boswell, hamail, hashboard）と同じrelease-drafter方式に移行する。

## 変更内容

### 新規: release-drafter
- `.github/workflows/release-drafter.yml` — masterへのpushでドラフトリリースを自動更新（boswellと同一構成、ブランチのみmaster）
- `.github/release-drafter.yml` — 設定もboswellと同一。`$RESOLVED_VERSION` 形式は既存タグ（`1.0.0` 等）と互換
- ラベル `major` / `minor` / `patch` / `feature` / `chore` をリポジトリに追加済み（バージョン解決はデフォルトpatch）

### 変更: release.yml
- トリガーを `push: tags` → `release: published` に変更
- `create-release@v1` を**削除**（リリースはドラフト公開で既に存在するため不要）
- `upload-release-asset@v1.0.1` → `gh release upload --clobber` に置換
- `permissions: contents: write` を明示
- tags-check（masterに含まれるタグかの検証）は維持

## 新しいリリースフロー

1. PRをmasterにマージ → release-drafterがドラフトを自動更新
2. GitHubでドラフトを公開 → タグ作成 → 本ワークフローがビルドしてZIPを添付

⚠️ **タグの手動pushではリリースが作られなくなる**（release: publishedイベントが発生しないため）。今後はドラフト公開がリリースの起点。

## 検証

- `actionlint` パス
- 本PRマージ時のmaster pushでrelease-drafterが初回ドラフトを作成するはず → マージ後に確認
- release.yml本体はドラフト公開時に実地検証（zipが添付されるだけで、本番デプロイには無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)