### PR TITLE
gh release uploadにGH_REPOを指定

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,5 @@ jobs:
         run: gh release upload ${{ github.event.release.tag_name }} ${{ github.event.repository.name }}.zip --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # build.shが.distignoreに従い.gitを削除するため、gitコンテキストに頼らずリポジトリを指定する
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## 概要

リリース 1.1.0 の公開時、新しい release.yml の「Upload Release Zip」が以下のエラーで失敗した。

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

## 原因

`bin/build.sh` が `.distignore` に従って `.git` ディレクトリを削除するため、`gh` CLIがカレントディレクトリからリポジトリを特定できない。

## 修正

`GH_REPO: ${{ github.repository }}` を環境変数で明示し、gitコンテキストへの依存を解消。

## 検証

マージ後、リリース 1.1.0 をドラフトに戻して再公開し、ZIPが添付されることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)