### PR TITLE
トップページ改修: WordPress活動ブロックのDOM追従とRecent Postsのタグ対応

### DIFF
--- a/app/Fumikito/Kyom/Service/WordPressOrg.php
+++ b/app/Fumikito/Kyom/Service/WordPressOrg.php
@@ -30,143 +30,227 @@ class WordPressOrg {
 	/**
 	 * Get WordPress.org profile.
 	 *
+	 * wp.org のプロフィールページ DOM は不定期に変わるため、変わりにくい箇所
+	 * （バッジ・リリース・プラグインslug一覧）だけをスクレイピングし、数値は
+	 * 公式 API から取得して堅牢化している。
+	 *
 	 * @param string $user_name
 	 * @return array
 	 */
 	public static function get_profile( $user_name ) {
-		$url  = self::get_profile_url( $user_name );
-		$data = get_transient( $url );
+		$url = self::get_profile_url( $user_name );
+		// DOM 構造が変わったのでキャッシュキーを v2 にして旧キャッシュを無効化する。
+		$cache_key = 'kyom_wporg_v2_' . md5( $url );
+		$data      = get_transient( $cache_key );
 		if ( false === $data ) {
 			$response = wp_remote_get( $url );
 			if ( is_wp_error( $response ) ) {
 				return [];
 			}
-			$data              = [];
-			$data['url']       = $url;
-			$data['downloads'] = 0;
-			$html5             = new HTML5();
-			$document          = $html5->loadHTML( $response['body'] );
-			// Get since.
-			$member_since = '';
-			$since_el     = $document->getElementById( 'user-member-since' );
+			$body = wp_remote_retrieve_body( $response );
+			if ( ! $body ) {
+				return [];
+			}
+			$data = [
+				'url'                   => $url,
+				'member_since'          => 0,
+				'badges'                => [],
+				'releases'              => [],
+				'active_installs_total' => 0,
+				'plugin_count'          => 0,
+				'last_updated'          => current_time( 'mysql' ),
+			];
+
+			$html5 = new HTML5();
+			// disable_html_ns を付けないと要素が XHTML 名前空間に入り、無修飾 XPath が一切マッチしない。
+			$document = $html5->loadHTML( $body, [ 'disable_html_ns' => true ] );
+			$xpath    = new \DOMXPath( $document );
+
+			// Member since（DOM 健在）.
+			$since_el = $document->getElementById( 'user-member-since' );
 			if ( $since_el ) {
+				$member_since = '';
 				foreach ( $since_el->getElementsByTagName( 'strong' ) as $strong ) {
 					/** @var \DOMElement $strong */
 					$member_since .= $strong->nodeValue;
 				}
-			}
-			if ( $member_since ) {
-				$data['member_since'] = strtotime( $member_since );
-			}
-			// Get badges.
-			$badges    = [];
-			$badges_el = $document->getElementById( 'user-badges' );
-			if ( $badges_el ) {
-				foreach ( $badges_el->getElementsByTagName( 'li' ) as $li ) {
-					$badge = [];
-					foreach ( $li->getElementsByTagName( 'div' ) as $div ) {
-						$badge['label'] = trim( $div->nextSibling->nodeValue );
-						$badge['class'] = explode( ' ', $div->getAttribute( 'class' ) );
-						if ( $badge['label'] && $badge['class'] ) {
-							$badges[] = $badge;
-						}
-					}
+				if ( $member_since ) {
+					$data['member_since'] = strtotime( $member_since );
 				}
 			}
-			$data['badges'] = $badges;
-			// Get plugins and themes
-			$data['downloads'] = 0;
-			foreach ( [
-				'theme',
-				'plugin',
-			] as $extension ) {
-				$id              = "content-{$extension}s";
-				$plugins         = [];
-				$plugin_download = 0;
-				$container       = $document->getElementById( $id );
-				if ( $container ) {
-					foreach ( $container->getElementsByTagName( 'li' ) as $li ) {
-						$plugin  = [];
-						$counter = 0;
-						foreach ( $li->getElementsByTagName( 'a' ) as $link ) {
-							if ( ( ! $counter && 'theme' === $extension ) || ( $counter && 'plugin' === $extension ) ) {
-								// Text Link.
-								$plugin['name']   = trim( $link->nodeValue );
-								$plugin['url']    = trim( $link->getAttribute( 'href' ) );
-								$plugin['rating'] = 0;
-								foreach ( $link->parentNode->getElementsByTagName( 'div' ) as $div ) {
-									$rating = trim( $div->getAttribute( 'title' ) );
-									if ( $rating ) {
-										if ( preg_match_all( '#\d#u', $rating, $match ) ) {
-											$plugin['rating'] = $match[0][0] / $match[0][1];
-										}
-									}
-								}
-								if ( 'theme' === $extension ) {
-									// Get screenshot
-									foreach ( $link->getElementsByTagName( 'img' ) as $image ) {
-										$plugin['screen_shot'] = $image->getAttribute( 'src' );
-									}
-								}
-							} elseif ( 'plugins' === $extension ) {
-								if ( preg_match_all( '#url\(\'([^\']+)(\d{3}x\d{3})([^\']+)\'\)#u', $link->nodeValue, $matches, PREG_SET_ORDER ) ) {
-									foreach ( $matches as $match ) {
-										$label            = '256x256' === $match[2] ? 'icon_large' : 'icon_small';
-										$plugin[ $label ] = $match[1] . $match[2] . $match[3];
-									}
-								}
-							}
-							++$counter;
-						}
-						// Get install counts.
-						foreach ( $li->getElementsByTagName( 'p' ) as $p ) {
-							$plugin['downloads'] = (int) preg_replace( '#\D#u', '', trim( $p->nodeValue ) );
-							$plugin_download    += $plugin['downloads'];
-						}
-						$plugins[] = $plugin;
-					}
-				}
-				$data[ $extension . 's' ]          = $plugins;
-				$data[ $extension . '_downloads' ] = $plugin_download;
-				$data['downloads']                += $plugin_download;
+
+			// Badges, releases.
+			$data['badges']   = self::parse_badges( $xpath );
+			$data['releases'] = self::parse_releases( $xpath );
+
+			// Plugins: slug 一覧だけスクレイプし、稼働インストール数は公式 API から正確に取得する。
+			$slugs                = self::parse_plugin_slugs( $xpath );
+			$data['plugin_count'] = count( $slugs );
+			$total                = 0;
+			foreach ( $slugs as $slug ) {
+				$total += self::get_plugin_active_installs( $slug );
 			}
-			// Get themes.
-			$data['last_updated'] = current_time( 'mysql' );
-			set_transient( $url, $data, 60 * 60 );
+			$data['active_installs_total'] = $total;
+
+			// TODO: 初回キャッシュミス時に slug 数ぶんの API リクエストが直列で走る。
+			// アクセス頻度が上がるようなら wp-cron での事前更新に切り出すこと。
+			set_transient( $cache_key, $data, 12 * HOUR_IN_SECONDS );
 		}
 		return $data;
 	}
 
 	/**
-	 * Get item
+	 * Parse badges from the new profile DOM.
 	 *
-	 * @param array $data
+	 * 新DOM: `.wp-p2-badges-block` 内のカテゴリ別 `span.medal.badge-XXX`。
+	 *
+	 * @param \DOMXPath $xpath
+	 * @return array
+	 */
+	private static function parse_badges( \DOMXPath $xpath ) {
+		$badges = [];
+		$medals = $xpath->query( "//span[contains(concat(' ', normalize-space(@class), ' '), ' medal ')]" );
+		if ( ! $medals ) {
+			return $badges;
+		}
+		foreach ( $medals as $medal ) {
+			/** @var \DOMElement $medal */
+			$label = self::query_text( $xpath, ".//*[contains(concat(' ', normalize-space(@class), ' '), ' mn ')]", $medal );
+			if ( ! $label ) {
+				continue;
+			}
+			$icon_nodes = $xpath->query( ".//*[contains(concat(' ', normalize-space(@class), ' '), ' mi ')]", $medal );
+			$icon_class = ( $icon_nodes && $icon_nodes->length ) ? $icon_nodes->item( 0 )->getAttribute( 'class' ) : '';
+			$badges[]   = [
+				'label'       => $label,
+				'year'        => self::query_text( $xpath, ".//*[contains(concat(' ', normalize-space(@class), ' '), ' myear ')]", $medal ),
+				'icon_class'  => $icon_class,
+				'badge_class' => $medal->getAttribute( 'class' ),
+				'title'       => $medal->getAttribute( 'title' ),
+			];
+		}
+		return $badges;
+	}
+
+	/**
+	 * Parse "WordPress releases" section.
+	 *
+	 * @param \DOMXPath $xpath
+	 * @return array{count:int, versions:array}|array
+	 */
+	private static function parse_releases( \DOMXPath $xpath ) {
+		$sections = $xpath->query( "//section[contains(concat(' ', normalize-space(@class), ' '), ' wp-p2-specs ')][normalize-space(h3)='WordPress releases']" );
+		if ( ! $sections || ! $sections->length ) {
+			return [];
+		}
+		$section = $sections->item( 0 );
+		$count   = 0;
+		$sub     = self::query_text( $xpath, ".//*[contains(concat(' ', normalize-space(@class), ' '), ' sub ')]", $section );
+		if ( $sub && preg_match( '/(\d+)/u', $sub, $m ) ) {
+			$count = (int) $m[1];
+		}
+		$versions = [];
+		$chips    = $xpath->query( ".//li[contains(concat(' ', normalize-space(@class), ' '), ' ver-chip ')]", $section );
+		if ( $chips ) {
+			foreach ( $chips as $chip ) {
+				/** @var \DOMElement $chip */
+				$number = self::query_text( $xpath, ".//*[contains(concat(' ', normalize-space(@class), ' '), ' ver-num ')]", $chip );
+				if ( ! $number ) {
+					continue;
+				}
+				$versions[] = [
+					'number' => $number,
+					'role'   => $chip->getAttribute( 'title' ),
+				];
+			}
+		}
+		return [
+			'count'    => $count,
+			'versions' => $versions,
+		];
+	}
+
+	/**
+	 * Parse plugin slugs from `#content-plugins`.
+	 *
+	 * @param \DOMXPath $xpath
+	 * @return string[]
+	 */
+	private static function parse_plugin_slugs( \DOMXPath $xpath ) {
+		$slugs = [];
+		$links = $xpath->query( "//div[@id='content-plugins']//a[contains(@href, '/plugins/')]" );
+		if ( ! $links ) {
+			return [];
+		}
+		foreach ( $links as $link ) {
+			/** @var \DOMElement $link */
+			if ( preg_match( '#/plugins/([^/]+)/#u', $link->getAttribute( 'href' ), $m ) ) {
+				$slugs[ $m[1] ] = $m[1]; // キーで重複排除.
+			}
+		}
+		return array_values( $slugs );
+	}
+
+	/**
+	 * Get accurate active installs for a plugin via the official API.
+	 *
+	 * @param string $slug
+	 * @return int
+	 */
+	private static function get_plugin_active_installs( $slug ) {
+		$api      = 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=' . rawurlencode( $slug );
+		$response = wp_remote_get( $api );
+		if ( is_wp_error( $response ) ) {
+			return 0;
+		}
+		$json = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $json ) || empty( $json['active_installs'] ) ) {
+			return 0;
+		}
+		return (int) $json['active_installs'];
+	}
+
+	/**
+	 * Get trimmed text of the first node matching an XPath expression.
+	 *
+	 * @param \DOMXPath    $xpath
+	 * @param string       $expr
+	 * @param \DOMNode|null $context
+	 * @return string
+	 */
+	private static function query_text( \DOMXPath $xpath, $expr, $context = null ) {
+		$nodes = $xpath->query( $expr, $context );
+		if ( $nodes && $nodes->length ) {
+			return trim( $nodes->item( 0 )->nodeValue );
+		}
+		return '';
+	}
+
+	/**
+	 * Get delivering item count label (plugins).
+	 *
+	 * @param array  $data
+	 * @param string $before
+	 * @param string $after
 	 * @return string
 	 */
 	public static function delivering_item_count( $data, $before, $after ) {
-		$label = [];
-		foreach ( [ 'theme', 'plugin' ] as $ext ) {
-			$downloads = count( $data[ $ext . 's' ] );
-			if ( ! $downloads ) {
-				continue;
-			}
-			switch ( $ext ) {
-				case 'theme':
-					$i18n = _n( '%s theme', '%s themes', $downloads, 'kyom' );
-					break;
-				case 'plugin':
-					$i18n = _n( '%s plugin', '%s plugins', $downloads, 'kyom' );
-					break;
-			}
-			$label[] = sprintf( $i18n, number_format( $downloads ) );
+		$count = $data['plugin_count'] ?? 0;
+		if ( ! $count ) {
+			return '';
 		}
-		return $label ? $before . implode( _x( ', ', 'csv-glue', 'kyom' ), $label ) . $after : '';
+		$label = sprintf(
+			/* translators: %s: Number of plugins. */
+			_n( '%s plugin', '%s plugins', $count, 'kyom' ),
+			number_format( $count )
+		);
+		return $before . $label . $after;
 	}
 
 	/**
 	 * Translate role.
 	 *
-	 * @param $role
+	 * @param string $role
 	 *
 	 * @return string
 	 */
@@ -197,5 +281,7 @@ class WordPressOrg {
 		_x( 'Translation', 'WordPress', 'kyom' );
 		_x( 'Team', 'WordPress', 'kyom' );
 		_x( 'Commiter', 'WordPress', 'kyom' );
+		_x( 'WordCamp', 'WordPress', 'kyom' );
+		_x( 'Meetup', 'WordPress', 'kyom' );
 	}
 }

--- a/src/blocks/recent/block.json
+++ b/src/blocks/recent/block.json
@@ -21,6 +21,10 @@
 		"tag": {
 			"type": "string",
 			"default": ""
+		},
+		"ignoreStickyPosts": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/src/blocks/recent/block.json
+++ b/src/blocks/recent/block.json
@@ -17,6 +17,10 @@
 		"category": {
 			"type": "string",
 			"default": ""
+		},
+		"tag": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/src/blocks/recent/edit.js
+++ b/src/blocks/recent/edit.js
@@ -1,13 +1,38 @@
 import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl, Placeholder } from '@wordpress/components';
+import { PanelBody, TextControl, ComboboxControl, Placeholder } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { postList } from '@wordpress/icons';
 import './editor.scss';
 
 export default function Edit( { attributes, setAttributes } ) {
-	const { title, category } = attributes;
+	const { title, category, tag } = attributes;
 
 	const blockProps = useBlockProps();
+
+	// カテゴリ・タグの一覧を取得（編集画面の選択肢として使う）。
+	const { categories, tags } = useSelect( ( select ) => {
+		const query = { per_page: -1, _fields: 'id,name,slug' };
+		return {
+			categories: select( coreStore ).getEntityRecords( 'taxonomy', 'category', query ),
+			tags: select( coreStore ).getEntityRecords( 'taxonomy', 'post_tag', query ),
+		};
+	}, [] );
+
+	// カテゴリは ID 指定（既存の WP_Query 'cat' と後方互換）。
+	const categoryOptions = ( categories || [] ).map( ( term ) => ( {
+		value: String( term.id ),
+		label: term.name,
+	} ) );
+	// タグはスラッグ指定（ターム ID は DB 間でズレるため）。
+	const tagOptions = ( tags || [] ).map( ( term ) => ( {
+		value: term.slug,
+		label: term.name,
+	} ) );
+
+	const selectedCategory = categoryOptions.find( ( opt ) => opt.value === String( category ) );
+	const selectedTag = tagOptions.find( ( opt ) => opt.value === tag );
 
 	return (
 		<>
@@ -19,12 +44,21 @@ export default function Edit( { attributes, setAttributes } ) {
 						onChange={ ( value ) => setAttributes( { title: value } ) }
 						help={ __( 'Leave empty for default title "Recent Posts"', 'kyom' ) }
 					/>
-					<TextControl
+					<ComboboxControl
 						label={ __( 'Category', 'kyom' ) }
-						value={ category }
-						onChange={ ( value ) => setAttributes( { category: value } ) }
-						help={ __( 'Enter category ID to filter posts', 'kyom' ) }
-						type="number"
+						value={ String( category ) }
+						options={ categoryOptions }
+						onChange={ ( value ) => setAttributes( { category: value || '' } ) }
+						help={ __( 'Filter posts by category (optional).', 'kyom' ) }
+						allowReset
+					/>
+					<ComboboxControl
+						label={ __( 'Tag', 'kyom' ) }
+						value={ tag }
+						options={ tagOptions }
+						onChange={ ( value ) => setAttributes( { tag: value || '' } ) }
+						help={ __( 'Filter posts by tag (optional).', 'kyom' ) }
+						allowReset
 					/>
 				</PanelBody>
 			</InspectorControls>
@@ -35,7 +69,8 @@ export default function Edit( { attributes, setAttributes } ) {
 					label={ title || __( 'Recent Posts', 'kyom' ) }
 					instructions={ __( 'Displays recent posts in a grid layout. Configure settings in the sidebar.', 'kyom' ) }
 				>
-					{ category && <p>{ __( 'Category ID:', 'kyom' ) } { category }</p> }
+					{ selectedCategory && <p>{ __( 'Category:', 'kyom' ) } { selectedCategory.label }</p> }
+					{ selectedTag && <p>{ __( 'Tag:', 'kyom' ) } { selectedTag.label }</p> }
 				</Placeholder>
 			</div>
 		</>

--- a/src/blocks/recent/edit.js
+++ b/src/blocks/recent/edit.js
@@ -1,13 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl, ComboboxControl, Placeholder } from '@wordpress/components';
+import { PanelBody, TextControl, ComboboxControl, ToggleControl, Placeholder } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { postList } from '@wordpress/icons';
 import './editor.scss';
 
 export default function Edit( { attributes, setAttributes } ) {
-	const { title, category, tag } = attributes;
+	const { title, category, tag, ignoreStickyPosts } = attributes;
 
 	const blockProps = useBlockProps();
 
@@ -59,6 +59,12 @@ export default function Edit( { attributes, setAttributes } ) {
 						onChange={ ( value ) => setAttributes( { tag: value || '' } ) }
 						help={ __( 'Filter posts by tag (optional).', 'kyom' ) }
 						allowReset
+					/>
+					<ToggleControl
+						label={ __( 'Ignore sticky posts', 'kyom' ) }
+						checked={ !! ignoreStickyPosts }
+						onChange={ ( value ) => setAttributes( { ignoreStickyPosts: value } ) }
+						help={ __( 'Sticky posts are only pinned to the top when no category/tag filter is set.', 'kyom' ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/src/blocks/recent/render.php
+++ b/src/blocks/recent/render.php
@@ -10,6 +10,7 @@
 
 $title    = $attributes['title'] ?? __( 'Recent Posts', 'kyom' );
 $category = $attributes['category'] ?? '';
+$tag      = $attributes['tag'] ?? '';
 
 $args = [
 	'post_type'      => 'post',
@@ -17,6 +18,10 @@ $args = [
 	'cat'            => $category,
 	'posts_per_page' => 5,
 ];
+// タグはスラッグ指定（ターム ID は DB 間でズレるため）。
+if ( $tag ) {
+	$args['tag'] = $tag;
+}
 
 $query = new WP_Query( $args );
 

--- a/src/blocks/recent/render.php
+++ b/src/blocks/recent/render.php
@@ -8,15 +8,18 @@
  * @var WP_Block $block      Block instance.
  */
 
-$title    = $attributes['title'] ?? __( 'Recent Posts', 'kyom' );
-$category = $attributes['category'] ?? '';
-$tag      = $attributes['tag'] ?? '';
+$title         = $attributes['title'] ?? __( 'Recent Posts', 'kyom' );
+$category      = $attributes['category'] ?? '';
+$tag           = $attributes['tag'] ?? '';
+$ignore_sticky = $attributes['ignoreStickyPosts'] ?? false;
 
 $args = [
-	'post_type'      => 'post',
-	'post_status'    => 'publish',
-	'cat'            => $category,
-	'posts_per_page' => 5,
+	'post_type'           => 'post',
+	'post_status'         => 'publish',
+	'cat'                 => $category,
+	'posts_per_page'      => 5,
+	// スティッキーの先頭固定はカテゴリ/タグ未指定（is_home 扱い）のときだけ発動する。
+	'ignore_sticky_posts' => (bool) $ignore_sticky,
 ];
 // タグはスラッグ指定（ターム ID は DB 間でズレるため）。
 if ( $tag ) {

--- a/src/blocks/wordpress-activities/render.php
+++ b/src/blocks/wordpress-activities/render.php
@@ -49,26 +49,48 @@ if ( did_action( 'template_redirect' ) ) {
 				<?php
 				foreach ( $data['badges'] as $badge ) :
 					$label = \Fumikito\Kyom\Service\WordPressOrg::translate_role( $badge['label'] );
+					$title = trim( $label . ' ' . ( $badge['year'] ?? '' ) );
 					?>
-				<span class="wporg-role">
-					<span class="<?php echo esc_attr( implode( ' ', $badge['class'] ) ); ?>" title="<?php echo esc_attr( $label ); ?>"></span>
+				<span class="wporg-role <?php echo esc_attr( $badge['badge_class'] ); ?>" title="<?php echo esc_attr( $title ); ?>">
+					<span class="<?php echo esc_attr( $badge['icon_class'] ); ?>"></span>
 					<span class="wporg-role-text uk-visible@s" aria-hidden="true"><?php echo esc_html( $label ); ?></span>
 				</span>
 
 				<?php endforeach; ?>
 			</div>
 		<?php endif; ?>
+		<?php if ( ! empty( $data['active_installs_total'] ) ) : ?>
 		<div class="wporg-downloads">
 			<small><?php esc_html_e( 'Total', 'kyom' ); ?></small>
-			<strong><?php echo number_format( $data['downloads'] ); ?></strong>
-			<small><?php echo esc_html( _n( 'Download', 'Downloads', $data['downloads'], 'kyom' ) ); ?></small>
+			<strong><?php echo number_format( $data['active_installs_total'] ); ?></strong>
+			<small><?php echo esc_html( _n( 'Active Install', 'Active Installs', $data['active_installs_total'], 'kyom' ) ); ?></small>
 			<?php echo \Fumikito\Kyom\Service\WordPressOrg::delivering_item_count( $data, '<span class="wporg-downloads-items">(', ')</span>' ); ?>
 		</div>
+		<?php endif; ?>
+		<?php if ( ! empty( $data['releases']['versions'] ) ) : ?>
+		<div class="wporg-releases uk-text-center">
+			<h3 class="wporg-releases-title">
+				<?php
+				printf(
+					/* translators: %s: Number of WordPress releases. */
+					esc_html( _n( 'Contributed to %s WordPress release', 'Contributed to %s WordPress releases', count( $data['releases']['versions'] ), 'kyom' ) ),
+					esc_html( number_format( $data['releases']['count'] ?: count( $data['releases']['versions'] ) ) )
+				);
+				?>
+			</h3>
+			<ul class="wporg-releases-versions">
+				<?php foreach ( $data['releases']['versions'] as $version ) : ?>
+					<li class="wporg-release-chip" title="<?php echo esc_attr( $version['role'] ); ?>"><?php echo esc_html( $version['number'] ); ?></li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+		<?php endif; ?>
 		<p class="wporg-profile">
 			<?php echo get_avatar( $user_mail, 360, '', $user_name, [ 'class' => 'wporg-avatar uk-border-circle' ] ); ?>
 			<a href="<?php echo esc_url( \Fumikito\Kyom\Service\WordPressOrg::get_profile_url( $user_name ) ); ?>" class="wporg-profile-link">
 				<?php echo esc_html( $user_name ); ?>
 			</a>
+			<br />
 			<small>
 				<?php
 				printf(

--- a/src/scss/kyom/blocks/_recent.scss
+++ b/src/scss/kyom/blocks/_recent.scss
@@ -8,7 +8,7 @@
   }
 
   &-list{
-    height: 300px;
+    height: 480px;
     display: flex;
     max-width: $breakpoint-medium;
     &-column{

--- a/src/scss/kyom/blocks/_wordpress-activities.scss
+++ b/src/scss/kyom/blocks/_wordpress-activities.scss
@@ -45,25 +45,27 @@
 			border-radius: 50%;
 			text-align: center;
 			vertical-align: middle;
-			&[class*="contributor"]{
-				color: $global-primary-background;
-				border-color: $global-primary-background;
-			}
-			&[class*="editor"],
-			&[class*="speaker"]{
-				color: $global-warning-background;
-				border-color: $global-warning-background;
-			}
-			&[class*="organizer"],
-			&[class*="commiter"]{
-				color: $global-danger-background;
-				border-color: $global-danger-background;
-			}
-			&[class*="plugins"],
-			&[class*="themes"]{
-				color: $global-visited-color;
-				border-color: $global-visited-color;
-			}
+		}
+		// 新DOMではアイコンクラス（dashicons-XXX）に役割名が含まれないため、
+		// 色分けはラッパに付与した badge-XXX クラスをキーにする。
+		&[class*="contributor"] .dashicons{
+			color: $global-primary-background;
+			border-color: $global-primary-background;
+		}
+		&[class*="editor"] .dashicons,
+		&[class*="speaker"] .dashicons{
+			color: $global-warning-background;
+			border-color: $global-warning-background;
+		}
+		&[class*="organizer"] .dashicons,
+		&[class*="commiter"] .dashicons{
+			color: $global-danger-background;
+			border-color: $global-danger-background;
+		}
+		&[class*="plugins"] .dashicons,
+		&[class*="themes"] .dashicons{
+			color: $global-visited-color;
+			border-color: $global-visited-color;
 		}
 	}
 
@@ -81,5 +83,37 @@
 			display: block;
 			font-size: 0.85rem;
 		}
+	}
+
+	&-releases{
+		margin: $kyom-gap auto 0;
+
+		&-title{
+			font-size: 1.1rem;
+			font-family: $font-sans;
+			color: $global-muted-color;
+			margin-bottom: 0.75em;
+		}
+
+		&-versions{
+			list-style: none;
+			margin: 0;
+			padding: 0;
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
+			gap: 0.5em;
+		}
+	}
+
+	&-release-chip{
+		display: inline-block;
+		padding: 0.15em 0.75em;
+		font-family: $font-mono;
+		font-size: 0.9rem;
+		line-height: 1.6;
+		color: #fff;
+		background-color: $wordpress-blue;
+		border-radius: 999px;
 	}
 }

--- a/src/scss/kyom/components/_footer_newsletter.scss
+++ b/src/scss/kyom/components/_footer_newsletter.scss
@@ -4,6 +4,10 @@
   background: url( "../img/newsletter-sample.jpeg") center center no-repeat;
   background-size: cover;
 
+	@media screen and (max-width: 767px ) {
+		padding: $kyom-gap 0;
+	}
+
   &-title{
     text-align: center;
     color: #fff;


### PR DESCRIPTION
## 概要

トップページ周りのブロックを改修。WordPress.org プロフィールのDOM刷新に追従し、Recent Posts ブロックをタグでも絞り込めるようにした。

## 変更内容

### 1. WordPress Activities ブロック（`section.wporg`）の wp.org DOM刷新対応
- スクレイパー（`WordPressOrg.php`）を新DOMに対応（`DOMXPath` 化、Masterminds HTML5 の `disable_html_ns` 必須）
- バッジ: 旧 `#user-badges` 廃止 → `.wp-p2-badges-block` 内 `span.medal.badge-*` をパース
- **WordPress releases** セクションを新規追加（貢献バージョンのチップ表示）
- 累計DL数は wp.org が公開廃止のため、**公式APIで取得した稼働インストール数（active installs）の合計**に作り替え
- transient キャッシュキーを v2 化（TTL 12h）

### 2. Recent Posts ブロックのタグ対応＋選択式UI
- `tag` 属性（スラッグ指定／DB間で安定）を追加し WP_Query で絞り込み
- カテゴリ・タグともテキスト入力 → 検索可能な `ComboboxControl`（`getEntityRecords` で一覧取得）
- カテゴリはID保持で後方互換、タグはスラッグ保持
- `ignoreStickyPosts` トグルを追加（カテゴリ/タグ未指定＝is_home時のみ固定記事が先頭に来る挙動を制御）

### 3. CSS微調整
- Recent リストの高さ 300px → 480px
- フッターニュースレターにモバイル余白（≤767px）

## 検証
- スクレイパー: `wp eval` で実データ取得を確認（バッジ9件 / 29プラグイン / active installs / 6リリース）
- タグ絞り込み: `wp eval` で WP_Query 挙動を実証
- 固定記事トグル: 一時sticky設定で先頭固定の有無を実証（テスト後に復元）
- エディタUI: Playwrightで Combobox・トグルの描画と属性反映、コンソールエラー0 を確認
- PHPCS / lint:js 通過

## 補足
- 累計DL数は wp.org が公開を完全廃止しており、本物のDL総数はどのAPIからも取得不可。active installs で代替している。
- 「読んでほしい」等のタグ絞り込み時は is_tag となり固定記事の先頭固定は元々発動しない（トグルは無関係）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)