### PR TITLE
Testimonialsスライダーを横一杯に複数表示

### DIFF
--- a/src/blocks/testimonials/render.php
+++ b/src/blocks/testimonials/render.php
@@ -43,14 +43,14 @@ if ( ! $posts ) {
 global $post;
 ?>
 <section class="testimonial-slider">
-	<div uk-slider="center: true; autoplay:true">
+	<div uk-slider="autoplay: true; autoplay-interval: 4000">
 		<div class="uk-position-relative uk-visible-toggle uk-light">
 			<ul class="uk-slider-items uk-grid">
 				<?php
 				foreach ( $posts as $post ) :
 					setup_postdata( $post );
 					?>
-					<li class="uk-width-3-4 uk-width-2-3@m">
+					<li class="uk-width-3-4 uk-width-1-2@s uk-width-1-3@m uk-width-1-4@l uk-width-1-5@xl">
 						<a href="<?php echo esc_url( get_permalink( $post ) ); ?>" class="testimonial-slider-item">
 						<div class="uk-card uk-card-default">
 							<div class="uk-card-body">

--- a/src/blocks/testimonials/render.php
+++ b/src/blocks/testimonials/render.php
@@ -43,38 +43,40 @@ if ( ! $posts ) {
 global $post;
 ?>
 <section class="testimonial-slider">
-	<div uk-slider="autoplay: true; autoplay-interval: 4000">
-		<div class="uk-position-relative uk-visible-toggle uk-light">
-			<ul class="uk-slider-items uk-grid">
-				<?php
-				foreach ( $posts as $post ) :
-					setup_postdata( $post );
-					?>
-					<li class="uk-width-3-4 uk-width-1-2@s uk-width-1-3@m uk-width-1-4@l uk-width-1-5@xl">
-						<a href="<?php echo esc_url( get_permalink( $post ) ); ?>" class="testimonial-slider-item">
-						<div class="uk-card uk-card-default">
-							<div class="uk-card-body">
-								<h3 class="uk-card-title">
-									<?php if ( has_post_thumbnail( $post ) ) : ?>
-										<?php echo get_the_post_thumbnail( $post, 'face-rectangle', [ 'class' => 'testimonial-slider-face' ] ); ?>
-									<?php endif; ?>
-									<?php echo esc_html( get_the_title( $post ) ); ?>
-								</h3>
-								<?php the_excerpt(); ?>
-							</div>
-						</div>
-						</a>
-					</li>
+	<div class="uk-container uk-container-expand">
+		<div uk-slider="autoplay: true; autoplay-interval: 4000">
+			<div class="uk-position-relative uk-visible-toggle uk-light">
+				<ul class="uk-slider-items uk-grid">
 					<?php
-				endforeach;
-				wp_reset_postdata();
-				?>
-			</ul>
-			<a class="uk-position-center-left uk-position-small uk-hidden-hover" href="#" uk-slidenav-previous
-				uk-slider-item="previous"></a>
-			<a class="uk-position-center-right uk-position-small uk-hidden-hover" href="#" uk-slidenav-next
-				uk-slider-item="next"></a>
+					foreach ( $posts as $post ) :
+						setup_postdata( $post );
+						?>
+						<li class="uk-width-3-4 uk-width-1-2@s uk-width-1-3@m uk-width-1-4@l uk-width-1-5@xl">
+							<a href="<?php echo esc_url( get_permalink( $post ) ); ?>" class="testimonial-slider-item">
+							<div class="uk-card uk-card-default">
+								<div class="uk-card-body">
+									<h3 class="uk-card-title">
+										<?php if ( has_post_thumbnail( $post ) ) : ?>
+											<?php echo get_the_post_thumbnail( $post, 'face-rectangle', [ 'class' => 'testimonial-slider-face' ] ); ?>
+										<?php endif; ?>
+										<?php echo esc_html( get_the_title( $post ) ); ?>
+									</h3>
+									<?php the_excerpt(); ?>
+								</div>
+							</div>
+							</a>
+						</li>
+						<?php
+					endforeach;
+					wp_reset_postdata();
+					?>
+				</ul>
+				<a class="uk-position-center-left uk-position-small uk-hidden-hover" href="#" uk-slidenav-previous
+					uk-slider-item="previous"></a>
+				<a class="uk-position-center-right uk-position-small uk-hidden-hover" href="#" uk-slidenav-next
+					uk-slider-item="next"></a>
+			</div>
+			<ul class="uk-slider-nav uk-dotnav uk-flex-center uk-margin"></ul>
 		</div>
-		<ul class="uk-slider-nav uk-dotnav uk-flex-center uk-margin"></ul>
 	</div>
 </section>


### PR DESCRIPTION
## 概要

トップページの Testimonials（お客様の声）スライダーが1枚しか表示されていなかったため、画面幅いっぱいにできるだけ多くのカードを並べるよう調整した。中身は Swiper ではなく UIkit の `uk-slider`。

## 変更内容
- スライド（`<li>`）の幅クラスをレスポンシブな分数に変更
  - `uk-width-3-4`（モバイル）→ `1-2@s` / `1-3@m` / `1-4@l` / `1-5@xl`
  - 画面が広いほど多く（PC幅で4枚程度）並ぶ
- `center: true` を解除（左詰めで全幅を有効活用）。`autoplay` は維持（4秒間隔）

## 検証
- ローカルに検証用 testimonial を一時追加（計6件）して Playwright で確認 → 1440px 幅で **4枚が横並び**、画面いっぱいに表示されることを確認（確認後テストデータは削除済み）
- 本番には testimonial が7件あり、本変更で複数表示される
- PHPCS / lint:js 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)